### PR TITLE
feat(auth): Google Authorization Code Flow endpoint (/auth/google)

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -1,1 +1,3 @@
 MONGODB_URI=mongodb://localhost:27017/shareyourgarden
+GOOGLE_REDIRECT_URI=http://localhost:1337/auth/google/callback
+FRONTEND_RETURN_TO_ALLOWLIST=http://localhost:4200

--- a/.env.default
+++ b/.env.default
@@ -1,1 +1,1 @@
-MONGO_URI=localhost:27017/shareyourgarden
+MONGODB_URI=mongodb://localhost:27017/shareyourgarden

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+PORT=1337
+MONGODB_URI=mongodb://localhost:27017/shareyourgarden
+
+GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_ALLOWED_REDIRECT_URIS=https://shareyourgarden-web.example.com,https://staging-shareyourgarden-web.example.com
+GOOGLE_AUTH_RATE_LIMIT_MAX=10
+GOOGLE_AUTH_RATE_LIMIT_WINDOW_MS=60000
+
+JWT_SECRET=replace-with-a-long-random-secret
+JWT_EXPIRES_IN=1d

--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,15 @@ MONGODB_URI=mongodb://localhost:27017/shareyourgarden
 
 GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-google-client-secret
-GOOGLE_ALLOWED_REDIRECT_URIS=https://shareyourgarden-web.example.com,https://staging-shareyourgarden-web.example.com
-GOOGLE_AUTH_RATE_LIMIT_MAX=10
-GOOGLE_AUTH_RATE_LIMIT_WINDOW_MS=60000
+GOOGLE_REDIRECT_URI=https://api.shareyourgarden.com/auth/google/callback
 
-JWT_SECRET=replace-with-a-long-random-secret
-JWT_EXPIRES_IN=1d
+# Exact origins and wildcard patterns supported with *
+FRONTEND_RETURN_TO_ALLOWLIST=https://shareyourgarden.com,https://deploy-preview-*.--shareyourgarden.netlify.app
+
+SESSION_SECRET=replace-with-a-long-random-secret
+SESSION_TTL_MS=86400000
+SESSION_COOKIE_NAME=syg_session
+CSRF_COOKIE_NAME=syg_csrf
+GOOGLE_OAUTH_STATE_TTL_SECONDS=600
+GOOGLE_AUTH_RATE_LIMIT_MAX=20
+GOOGLE_AUTH_RATE_LIMIT_WINDOW_MS=60000

--- a/README.md
+++ b/README.md
@@ -1,76 +1,79 @@
 # shareyourgarden-backend
 
-Backend API (NestJS + MongoDB) para ShareYourGarden.
+Backend NestJS con OAuth2 Google en modo **broker backend** (redirect fijo del API), compatible con dominios variables de Netlify Deploy Previews.
 
-## Configuración
+## Variables de entorno
 
-1. Copia variables de entorno:
+Copia `.env.example` a `.env`.
 
-```bash
-cp .env.example .env
-```
+Variables requeridas:
 
-2. Ajusta valores en `.env`:
-
-- `MONGODB_URI`
 - `GOOGLE_CLIENT_ID`
 - `GOOGLE_CLIENT_SECRET`
-- `GOOGLE_ALLOWED_REDIRECT_URIS` (CSV)
-- `JWT_SECRET`
-- `JWT_EXPIRES_IN`
-- `GOOGLE_AUTH_RATE_LIMIT_MAX` (opcional)
-- `GOOGLE_AUTH_RATE_LIMIT_WINDOW_MS` (opcional)
+- `GOOGLE_REDIRECT_URI` (callback fijo backend, ej. `https://api.tudominio.com/auth/google/callback`)
+- `FRONTEND_RETURN_TO_ALLOWLIST` (CSV de orígenes permitidos; soporta `*`)
+- `SESSION_SECRET`
 
-## Scripts
+## Google Cloud Console (OAuth)
+
+1. En **APIs & Services > Credentials**, crea OAuth Client (Web application).
+2. En **Authorized redirect URIs**, agrega el callback backend fijo:
+   - `https://api.tudominio.com/auth/google/callback`
+3. En **Authorized JavaScript origins** agrega solo los orígenes que usen flujo browser directo (si aplica).
+4. Usa el `Client ID` y `Client Secret` en `.env`.
+
+## Endpoints de auth broker
+
+### `GET /auth/google/start?return_to=<frontend_url>`
+Valida `return_to`, firma `state`, setea nonce anti-CSRF y redirige a Google.
+
+### `GET /auth/google/callback`
+Valida `state` + nonce, intercambia `code`, verifica `id_token`, crea sesión con cookie segura y redirige a `return_to`.
+
+### `GET /auth/session`
+Contrato JSON:
+
+```json
+{
+  "authenticated": true,
+  "user": {
+    "sub": "google-sub",
+    "email": "user@example.com",
+    "name": "User",
+    "picture": "https://..."
+  }
+}
+```
+
+O sin sesión:
+
+```json
+{
+  "authenticated": false
+}
+```
+
+### `POST /auth/logout`
+Requiere header `x-csrf-token` que coincida con cookie CSRF. Invalida sesión y limpia cookies.
+
+Contrato JSON:
+
+```json
+{
+  "success": true
+}
+```
+
+## CORS y cookies
+
+- CORS dinámico contra `FRONTEND_RETURN_TO_ALLOWLIST`
+- `Access-Control-Allow-Credentials: true`
+- Cookies de sesión: `HttpOnly`, `Secure`, `SameSite=None`, `Path=/`
+
+## Tests
 
 ```bash
-yarn install
-yarn start:dev
-yarn test
-yarn test:e2e
+yarn lint
+yarn test --runInBand
+yarn test:e2e --runInBand
 ```
-
-## Auth con Google (Authorization Code Flow)
-
-### Endpoint
-
-`POST /auth/google`
-
-### Request
-
-```json
-{
-  "code": "AUTH_CODE_FROM_GOOGLE",
-  "redirectUri": "https://<frontend-origin>"
-}
-```
-
-### Response
-
-```json
-{
-  "user": {
-    "name": "string",
-    "email": "string",
-    "picture": "string",
-    "sub": "string"
-  },
-  "token": "APP_JWT"
-}
-```
-
-### Validaciones y seguridad
-
-- Solo se confía en `code` y `redirectUri` enviados por frontend.
-- `redirectUri` se valida contra `GOOGLE_ALLOWED_REDIRECT_URIS`.
-- Se intercambia el `code` contra Google Token Endpoint.
-- Se verifica `id_token` (firma RS256, issuer, audience, exp, claims).
-- Se aplica rate-limit básico por IP para `/auth/google`.
-
-### Códigos de error esperados
-
-- `400` request inválido (payload)
-- `401` code/token inválido
-- `403` origen/redirectUri no permitido
-- `429` demasiados intentos
-- `500` error interno

--- a/README.md
+++ b/README.md
@@ -1,99 +1,76 @@
-<p align="center">
-  <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo-small.svg" width="120" alt="Nest Logo" /></a>
-</p>
+# shareyourgarden-backend
 
-[circleci-image]: https://img.shields.io/circleci/build/github/nestjs/nest/master?token=abc123def456
-[circleci-url]: https://circleci.com/gh/nestjs/nest
+Backend API (NestJS + MongoDB) para ShareYourGarden.
 
-  <p align="center">A progressive <a href="http://nodejs.org" target="_blank">Node.js</a> framework for building efficient and scalable server-side applications.</p>
-    <p align="center">
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/v/@nestjs/core.svg" alt="NPM Version" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/l/@nestjs/core.svg" alt="Package License" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/dm/@nestjs/common.svg" alt="NPM Downloads" /></a>
-<a href="https://circleci.com/gh/nestjs/nest" target="_blank"><img src="https://img.shields.io/circleci/build/github/nestjs/nest/master" alt="CircleCI" /></a>
-<a href="https://coveralls.io/github/nestjs/nest?branch=master" target="_blank"><img src="https://coveralls.io/repos/github/nestjs/nest/badge.svg?branch=master#9" alt="Coverage" /></a>
-<a href="https://discord.gg/G7Qnnhy" target="_blank"><img src="https://img.shields.io/badge/discord-online-brightgreen.svg" alt="Discord"/></a>
-<a href="https://opencollective.com/nest#backer" target="_blank"><img src="https://opencollective.com/nest/backers/badge.svg" alt="Backers on Open Collective" /></a>
-<a href="https://opencollective.com/nest#sponsor" target="_blank"><img src="https://opencollective.com/nest/sponsors/badge.svg" alt="Sponsors on Open Collective" /></a>
-  <a href="https://paypal.me/kamilmysliwiec" target="_blank"><img src="https://img.shields.io/badge/Donate-PayPal-ff3f59.svg" alt="Donate us"/></a>
-    <a href="https://opencollective.com/nest#sponsor"  target="_blank"><img src="https://img.shields.io/badge/Support%20us-Open%20Collective-41B883.svg" alt="Support us"></a>
-  <a href="https://twitter.com/nestframework" target="_blank"><img src="https://img.shields.io/twitter/follow/nestframework.svg?style=social&label=Follow" alt="Follow us on Twitter"></a>
-</p>
-  <!--[![Backers on Open Collective](https://opencollective.com/nest/backers/badge.svg)](https://opencollective.com/nest#backer)
-  [![Sponsors on Open Collective](https://opencollective.com/nest/sponsors/badge.svg)](https://opencollective.com/nest#sponsor)-->
+## Configuración
 
-## Description
-
-[Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
-
-## Project setup
+1. Copia variables de entorno:
 
 ```bash
-$ yarn install
+cp .env.example .env
 ```
 
-## Compile and run the project
+2. Ajusta valores en `.env`:
+
+- `MONGODB_URI`
+- `GOOGLE_CLIENT_ID`
+- `GOOGLE_CLIENT_SECRET`
+- `GOOGLE_ALLOWED_REDIRECT_URIS` (CSV)
+- `JWT_SECRET`
+- `JWT_EXPIRES_IN`
+- `GOOGLE_AUTH_RATE_LIMIT_MAX` (opcional)
+- `GOOGLE_AUTH_RATE_LIMIT_WINDOW_MS` (opcional)
+
+## Scripts
 
 ```bash
-# development
-$ yarn run start
-
-# watch mode
-$ yarn run start:dev
-
-# production mode
-$ yarn run start:prod
+yarn install
+yarn start:dev
+yarn test
+yarn test:e2e
 ```
 
-## Run tests
+## Auth con Google (Authorization Code Flow)
 
-```bash
-# unit tests
-$ yarn run test
+### Endpoint
 
-# e2e tests
-$ yarn run test:e2e
+`POST /auth/google`
 
-# test coverage
-$ yarn run test:cov
+### Request
+
+```json
+{
+  "code": "AUTH_CODE_FROM_GOOGLE",
+  "redirectUri": "https://<frontend-origin>"
+}
 ```
 
-## Deployment
+### Response
 
-When you're ready to deploy your NestJS application to production, there are some key steps you can take to ensure it runs as efficiently as possible. Check out the [deployment documentation](https://docs.nestjs.com/deployment) for more information.
-
-If you are looking for a cloud-based platform to deploy your NestJS application, check out [Mau](https://mau.nestjs.com), our official platform for deploying NestJS applications on AWS. Mau makes deployment straightforward and fast, requiring just a few simple steps:
-
-```bash
-$ yarn install -g mau
-$ mau deploy
+```json
+{
+  "user": {
+    "name": "string",
+    "email": "string",
+    "picture": "string",
+    "sub": "string"
+  },
+  "token": "APP_JWT"
+}
 ```
 
-With Mau, you can deploy your application in just a few clicks, allowing you to focus on building features rather than managing infrastructure.
+### Validaciones y seguridad
 
-## Resources
+- Solo se confía en `code` y `redirectUri` enviados por frontend.
+- `redirectUri` se valida contra `GOOGLE_ALLOWED_REDIRECT_URIS`.
+- Se intercambia el `code` contra Google Token Endpoint.
+- Se verifica `id_token` (firma RS256, issuer, audience, exp, claims).
+- Se aplica rate-limit básico por IP para `/auth/google`.
 
-Check out a few resources that may come in handy when working with NestJS:
+### Códigos de error esperados
 
-- Visit the [NestJS Documentation](https://docs.nestjs.com) to learn more about the framework.
-- For questions and support, please visit our [Discord channel](https://discord.gg/G7Qnnhy).
-- To dive deeper and get more hands-on experience, check out our official video [courses](https://courses.nestjs.com/).
-- Deploy your application to AWS with the help of [NestJS Mau](https://mau.nestjs.com) in just a few clicks.
-- Visualize your application graph and interact with the NestJS application in real-time using [NestJS Devtools](https://devtools.nestjs.com).
-- Need help with your project (part-time to full-time)? Check out our official [enterprise support](https://enterprise.nestjs.com).
-- To stay in the loop and get updates, follow us on [X](https://x.com/nestframework) and [LinkedIn](https://linkedin.com/company/nestjs).
-- Looking for a job, or have a job to offer? Check out our official [Jobs board](https://jobs.nestjs.com).
-
-## Support
-
-Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).
-
-## Stay in touch
-
-- Author - [Kamil Myśliwiec](https://twitter.com/kammysliwiec)
-- Website - [https://nestjs.com](https://nestjs.com/)
-- Twitter - [@nestframework](https://twitter.com/nestframework)
-
-## License
-
-Nest is [MIT licensed](https://github.com/nestjs/nest/blob/master/LICENSE).
+- `400` request inválido (payload)
+- `401` code/token inválido
+- `403` origen/redirectUri no permitido
+- `429` demasiados intentos
+- `500` error interno

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,13 +1,17 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { MongooseModule } from '@nestjs/mongoose';
+import { env } from 'process';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { AuthModule } from './auth/auth.module';
 import { GardensModule } from './gardens/gardens.module';
-import { env } from 'process';
 
 @Module({
   imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
     GardensModule,
+    AuthModule,
     MongooseModule.forRoot(
       env.MONGODB_URI || 'mongodb://localhost:27017/shareyourgarden',
     ),

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,12 +1,15 @@
 import {
-  Body,
   Controller,
+  Get,
   HttpCode,
   HttpStatus,
   Post,
+  Query,
+  Req,
+  Res,
   UseGuards,
 } from '@nestjs/common';
-import { GoogleAuthDto } from './dto/google-auth.dto';
+import { Request, Response } from 'express';
 import { GoogleAuthRateLimitGuard } from './guards/google-auth-rate-limit.guard';
 import { AuthService } from './services/auth.service';
 
@@ -14,10 +17,26 @@ import { AuthService } from './services/auth.service';
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
-  @Post('google')
-  @HttpCode(HttpStatus.OK)
+  @Get('google/start')
   @UseGuards(GoogleAuthRateLimitGuard)
-  loginWithGoogle(@Body() dto: GoogleAuthDto) {
-    return this.authService.loginWithGoogle(dto);
+  startGoogleAuth(@Query('return_to') returnTo: string, @Res() res: Response) {
+    this.authService.startGoogleAuth(returnTo, res);
+  }
+
+  @Get('google/callback')
+  @UseGuards(GoogleAuthRateLimitGuard)
+  async googleCallback(@Req() req: Request, @Res() res: Response) {
+    await this.authService.handleGoogleCallback(req, res);
+  }
+
+  @Get('session')
+  getSession(@Req() req: Request) {
+    return this.authService.getSession(req);
+  }
+
+  @Post('logout')
+  @HttpCode(HttpStatus.OK)
+  logout(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
+    return this.authService.logout(req, res);
   }
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,0 +1,23 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { GoogleAuthDto } from './dto/google-auth.dto';
+import { GoogleAuthRateLimitGuard } from './guards/google-auth-rate-limit.guard';
+import { AuthService } from './services/auth.service';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('google')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(GoogleAuthRateLimitGuard)
+  loginWithGoogle(@Body() dto: GoogleAuthDto) {
+    return this.authService.loginWithGoogle(dto);
+  }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,11 +1,14 @@
 import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 import { AuthController } from './auth.controller';
-import { User, UserSchema } from './schemas/user.schema';
-import { AuthService } from './services/auth.service';
-import { GoogleOAuthService } from './services/google-oauth.service';
-import { UsersService } from './services/users.service';
 import { GoogleAuthRateLimitGuard } from './guards/google-auth-rate-limit.guard';
+import { User, UserSchema } from './schemas/user.schema';
+import { AuthFlowService } from './services/auth-flow.service';
+import { AuthService } from './services/auth.service';
+import { CookieService } from './services/cookie.service';
+import { GoogleOAuthService } from './services/google-oauth.service';
+import { SessionService } from './services/session.service';
+import { UsersService } from './services/users.service';
 
 @Module({
   imports: [
@@ -14,7 +17,10 @@ import { GoogleAuthRateLimitGuard } from './guards/google-auth-rate-limit.guard'
   controllers: [AuthController],
   providers: [
     AuthService,
+    AuthFlowService,
+    CookieService,
     GoogleOAuthService,
+    SessionService,
     UsersService,
     GoogleAuthRateLimitGuard,
   ],

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { AuthController } from './auth.controller';
+import { User, UserSchema } from './schemas/user.schema';
+import { AuthService } from './services/auth.service';
+import { GoogleOAuthService } from './services/google-oauth.service';
+import { UsersService } from './services/users.service';
+import { GoogleAuthRateLimitGuard } from './guards/google-auth-rate-limit.guard';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: User.name, schema: UserSchema }]),
+  ],
+  controllers: [AuthController],
+  providers: [
+    AuthService,
+    GoogleOAuthService,
+    UsersService,
+    GoogleAuthRateLimitGuard,
+  ],
+})
+export class AuthModule {}

--- a/src/auth/dto/google-auth.dto.spec.ts
+++ b/src/auth/dto/google-auth.dto.spec.ts
@@ -1,0 +1,25 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { GoogleAuthDto } from './google-auth.dto';
+
+describe('GoogleAuthDto', () => {
+  it('validates a proper payload', async () => {
+    const dto = plainToInstance(GoogleAuthDto, {
+      code: 'auth-code',
+      redirectUri: 'https://shareyourgarden.app',
+    });
+
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('fails when fields are missing or invalid', async () => {
+    const dto = plainToInstance(GoogleAuthDto, {
+      code: '',
+      redirectUri: 'invalid',
+    });
+
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/src/auth/dto/google-auth.dto.ts
+++ b/src/auth/dto/google-auth.dto.ts
@@ -1,0 +1,12 @@
+import { IsNotEmpty, IsString, IsUrl } from 'class-validator';
+
+export class GoogleAuthDto {
+  @IsString()
+  @IsNotEmpty()
+  code: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @IsUrl({ require_tld: false }, { message: 'redirectUri must be a valid URL' })
+  redirectUri: string;
+}

--- a/src/auth/guards/google-auth-rate-limit.guard.ts
+++ b/src/auth/guards/google-auth-rate-limit.guard.ts
@@ -1,0 +1,47 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  HttpException,
+  Injectable,
+} from '@nestjs/common';
+import { Request } from 'express';
+
+interface RateLimitEntry {
+  count: number;
+  resetAt: number;
+}
+
+@Injectable()
+export class GoogleAuthRateLimitGuard implements CanActivate {
+  private readonly maxAttempts = Number.parseInt(
+    process.env.GOOGLE_AUTH_RATE_LIMIT_MAX ?? '10',
+    10,
+  );
+
+  private readonly windowMs = Number.parseInt(
+    process.env.GOOGLE_AUTH_RATE_LIMIT_WINDOW_MS ?? '60000',
+    10,
+  );
+
+  private readonly attempts = new Map<string, RateLimitEntry>();
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<Request>();
+    const ip = request.ip ?? request.headers['x-forwarded-for'] ?? 'unknown';
+    const key = Array.isArray(ip) ? ip[0] : String(ip);
+    const now = Date.now();
+
+    const current = this.attempts.get(key);
+    if (!current || current.resetAt <= now) {
+      this.attempts.set(key, { count: 1, resetAt: now + this.windowMs });
+      return true;
+    }
+
+    if (current.count >= this.maxAttempts) {
+      throw new HttpException('Too many auth attempts', 429);
+    }
+
+    current.count += 1;
+    return true;
+  }
+}

--- a/src/auth/schemas/user.schema.ts
+++ b/src/auth/schemas/user.schema.ts
@@ -1,0 +1,27 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument } from 'mongoose';
+
+export type UserDocument = HydratedDocument<User>;
+
+@Schema({ timestamps: true })
+export class User {
+  @Prop({ required: true })
+  name: string;
+
+  @Prop({ required: true, unique: true, lowercase: true, trim: true })
+  email: string;
+
+  @Prop()
+  picture?: string;
+
+  @Prop({ unique: true, sparse: true })
+  googleSub?: string;
+
+  @Prop({ default: 'google' })
+  provider: 'google';
+
+  @Prop({ type: [String], default: ['user'] })
+  roles: string[];
+}
+
+export const UserSchema = SchemaFactory.createForClass(User);

--- a/src/auth/services/auth-flow.service.spec.ts
+++ b/src/auth/services/auth-flow.service.spec.ts
@@ -1,0 +1,45 @@
+import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import { AuthFlowService } from './auth-flow.service';
+
+describe('AuthFlowService', () => {
+  let service: AuthFlowService;
+
+  beforeEach(() => {
+    process.env.SESSION_SECRET = 'session-secret';
+    process.env.FRONTEND_RETURN_TO_ALLOWLIST =
+      'https://shareyourgarden.com,https://deploy-preview-*.--shareyourgarden.netlify.app';
+    service = new AuthFlowService();
+  });
+
+  it('creates and verifies signed oauth state', () => {
+    const { state, nonce } = service.createOAuthState(
+      'https://deploy-preview-123.--shareyourgarden.netlify.app/dashboard',
+    );
+
+    const payload = service.verifyOAuthState(state);
+    expect(payload.returnTo).toContain('deploy-preview-123');
+    expect(payload.nonce).toBe(nonce);
+  });
+
+  it('validates preview return_to using wildcard allowlist', () => {
+    expect(() =>
+      service.validateReturnTo(
+        'https://deploy-preview-321.--shareyourgarden.netlify.app',
+      ),
+    ).not.toThrow();
+  });
+
+  it('rejects non-allowlisted return_to', () => {
+    expect(() => service.validateReturnTo('https://evil.example.com')).toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('fails on tampered state signature', () => {
+    const { state } = service.createOAuthState('https://shareyourgarden.com');
+    const tampered = `${state}x`;
+    expect(() => service.verifyOAuthState(tampered)).toThrow(
+      UnauthorizedException,
+    );
+  });
+});

--- a/src/auth/services/auth-flow.service.ts
+++ b/src/auth/services/auth-flow.service.ts
@@ -1,0 +1,152 @@
+import {
+  ForbiddenException,
+  Injectable,
+  InternalServerErrorException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { createHmac, randomBytes, timingSafeEqual } from 'crypto';
+
+interface OAuthStatePayload {
+  returnTo: string;
+  nonce: string;
+  iat: number;
+  exp: number;
+}
+
+@Injectable()
+export class AuthFlowService {
+  private readonly stateTtlSeconds = Number.parseInt(
+    process.env.GOOGLE_OAUTH_STATE_TTL_SECONDS ?? '600',
+    10,
+  );
+
+  private readonly secret = process.env.SESSION_SECRET;
+
+  createOAuthState(returnTo: string): { state: string; nonce: string } {
+    const now = Math.floor(Date.now() / 1000);
+    const nonce = randomBytes(16).toString('hex');
+    const payload: OAuthStatePayload = {
+      returnTo,
+      nonce,
+      iat: now,
+      exp: now + this.stateTtlSeconds,
+    };
+
+    return {
+      state: this.sign(payload),
+      nonce,
+    };
+  }
+
+  verifyOAuthState(state: string): OAuthStatePayload {
+    const payload = this.verify<OAuthStatePayload>(state);
+
+    if (!payload.returnTo || !payload.nonce || !payload.exp) {
+      throw new UnauthorizedException('Invalid OAuth state payload');
+    }
+
+    if (payload.exp <= Math.floor(Date.now() / 1000)) {
+      throw new UnauthorizedException('Expired OAuth state');
+    }
+
+    return payload;
+  }
+
+  validateReturnTo(returnTo: string): void {
+    const allowlist = this.getReturnToAllowlist();
+    let parsed: URL;
+
+    try {
+      parsed = new URL(returnTo);
+    } catch {
+      throw new ForbiddenException('Invalid return_to URL');
+    }
+
+    const origin = parsed.origin;
+    const isAllowed = allowlist.some((pattern) =>
+      this.matchesPattern(origin, pattern),
+    );
+
+    if (!isAllowed) {
+      throw new ForbiddenException('return_to is not allowed');
+    }
+  }
+
+  ensureNonceMatches(
+    cookieNonce: string | undefined,
+    stateNonce: string,
+  ): void {
+    if (!cookieNonce) {
+      throw new UnauthorizedException('Missing OAuth nonce cookie');
+    }
+
+    const left = Buffer.from(cookieNonce);
+    const right = Buffer.from(stateNonce);
+
+    if (left.length !== right.length || !timingSafeEqual(left, right)) {
+      throw new UnauthorizedException('Invalid OAuth nonce');
+    }
+  }
+
+  getReturnToAllowlist(): string[] {
+    return (process.env.FRONTEND_RETURN_TO_ALLOWLIST ?? '')
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+
+  private sign(payload: object): string {
+    if (!this.secret) {
+      throw new InternalServerErrorException(
+        'SESSION_SECRET is not configured',
+      );
+    }
+
+    const encodedPayload = Buffer.from(JSON.stringify(payload)).toString(
+      'base64url',
+    );
+    const signature = createHmac('sha256', this.secret)
+      .update(encodedPayload)
+      .digest('base64url');
+    return `${encodedPayload}.${signature}`;
+  }
+
+  private verify<T>(token: string): T {
+    if (!this.secret) {
+      throw new InternalServerErrorException(
+        'SESSION_SECRET is not configured',
+      );
+    }
+
+    const [encodedPayload, signature] = token.split('.');
+    if (!encodedPayload || !signature) {
+      throw new UnauthorizedException('Malformed signed state');
+    }
+
+    const expected = createHmac('sha256', this.secret)
+      .update(encodedPayload)
+      .digest('base64url');
+
+    const left = Buffer.from(signature);
+    const right = Buffer.from(expected);
+    if (left.length !== right.length || !timingSafeEqual(left, right)) {
+      throw new UnauthorizedException('Invalid state signature');
+    }
+
+    return JSON.parse(
+      Buffer.from(encodedPayload, 'base64url').toString('utf8'),
+    ) as T;
+  }
+
+  private matchesPattern(value: string, pattern: string): boolean {
+    if (!pattern.includes('*')) {
+      return value === pattern;
+    }
+
+    const escaped = pattern
+      .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+      .replace(/\*/g, '.*');
+    const regex = new RegExp(`^${escaped}$`);
+    return regex.test(value);
+  }
+}

--- a/src/auth/services/auth.service.spec.ts
+++ b/src/auth/services/auth.service.spec.ts
@@ -1,25 +1,46 @@
-import { InternalServerErrorException } from '@nestjs/common';
+import { ForbiddenException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { Request, Response } from 'express';
+import { AuthFlowService } from './auth-flow.service';
 import { AuthService } from './auth.service';
+import { CookieService } from './cookie.service';
 import { GoogleOAuthService } from './google-oauth.service';
+import { SessionService } from './session.service';
 import { UsersService } from './users.service';
 
 describe('AuthService', () => {
   let service: AuthService;
 
   const googleOAuthServiceMock = {
-    validateRedirectUri: jest.fn(),
     exchangeCodeForIdToken: jest.fn(),
     verifyIdToken: jest.fn(),
+  };
+
+  const authFlowServiceMock = {
+    validateReturnTo: jest.fn(),
+    createOAuthState: jest.fn(),
+    verifyOAuthState: jest.fn(),
+    ensureNonceMatches: jest.fn(),
   };
 
   const usersServiceMock = {
     findOrCreateFromGoogle: jest.fn(),
   };
 
+  const cookieServiceMock = {
+    parseCookies: jest.fn(),
+  };
+
+  const sessionServiceMock = {
+    createSession: jest.fn(),
+    getSession: jest.fn(),
+    invalidateSession: jest.fn(),
+  };
+
   beforeEach(async () => {
-    process.env.JWT_SECRET = 'jwt-secret';
-    process.env.JWT_EXPIRES_IN = '1h';
+    process.env.GOOGLE_CLIENT_ID = 'google-client-id';
+    process.env.GOOGLE_REDIRECT_URI =
+      'https://api.shareyourgarden.com/auth/google/callback';
 
     jest.clearAllMocks();
 
@@ -27,60 +48,111 @@ describe('AuthService', () => {
       providers: [
         AuthService,
         { provide: GoogleOAuthService, useValue: googleOAuthServiceMock },
+        { provide: AuthFlowService, useValue: authFlowServiceMock },
         { provide: UsersService, useValue: usersServiceMock },
+        { provide: CookieService, useValue: cookieServiceMock },
+        { provide: SessionService, useValue: sessionServiceMock },
       ],
     }).compile();
 
     service = module.get<AuthService>(AuthService);
   });
 
-  it('returns user and app token on successful login', async () => {
-    googleOAuthServiceMock.exchangeCodeForIdToken.mockResolvedValue('id-token');
-    googleOAuthServiceMock.verifyIdToken.mockResolvedValue({
-      sub: 'sub-1',
-      email: 'test@mail.com',
-      name: 'Test',
-      picture: 'pic',
-    });
-    usersServiceMock.findOrCreateFromGoogle.mockResolvedValue({
-      id: 'user-1',
-      email: 'test@mail.com',
-      name: 'Test',
-      picture: 'pic',
-      roles: ['user'],
+  it('starts google auth and redirects to google', () => {
+    const cookieMock = jest.fn();
+    const redirectMock = jest.fn();
+    const res = {
+      cookie: cookieMock,
+      redirect: redirectMock,
+    } as unknown as Response;
+
+    authFlowServiceMock.createOAuthState.mockReturnValue({
+      state: 'signed-state',
+      nonce: 'nonce',
     });
 
-    const result = await service.loginWithGoogle({
-      code: 'code',
-      redirectUri: 'https://shareyourgarden.app',
-    });
+    service.startGoogleAuth('https://shareyourgarden.com', res);
 
-    expect(result.user.email).toBe('test@mail.com');
-    expect(result.token.split('.')).toHaveLength(3);
+    expect(cookieMock).toHaveBeenCalled();
+    expect(redirectMock).toHaveBeenCalledWith(
+      expect.stringContaining('https://accounts.google.com/o/oauth2/v2/auth?'),
+    );
   });
 
-  it('fails if JWT secret is missing', async () => {
-    delete process.env.JWT_SECRET;
+  it('handles callback and creates session cookies', async () => {
+    const req = {
+      query: { code: 'code', state: 'state' },
+      headers: { cookie: 'syg_oauth_nonce=nonce' },
+    } as unknown as Request;
+    const cookieMock = jest.fn();
+    const clearCookieMock = jest.fn();
+    const redirectMock = jest.fn();
+    const res = {
+      cookie: cookieMock,
+      clearCookie: clearCookieMock,
+      redirect: redirectMock,
+    } as unknown as Response;
+
+    authFlowServiceMock.verifyOAuthState.mockReturnValue({
+      returnTo: 'https://shareyourgarden.com/app',
+      nonce: 'nonce',
+    });
+    cookieServiceMock.parseCookies.mockReturnValue({
+      syg_oauth_nonce: 'nonce',
+    });
     googleOAuthServiceMock.exchangeCodeForIdToken.mockResolvedValue('id-token');
     googleOAuthServiceMock.verifyIdToken.mockResolvedValue({
-      sub: 'sub-1',
-      email: 'test@mail.com',
-      name: 'Test',
+      sub: 'google-sub',
+      email: 'user@test.com',
+      name: 'User',
       picture: 'pic',
     });
     usersServiceMock.findOrCreateFromGoogle.mockResolvedValue({
-      id: 'user-1',
-      email: 'test@mail.com',
-      name: 'Test',
+      email: 'user@test.com',
+      name: 'User',
       picture: 'pic',
-      roles: ['user'],
+    });
+    sessionServiceMock.createSession.mockReturnValue({
+      id: 'session-id',
+      csrfToken: 'csrf-token',
     });
 
-    await expect(
-      service.loginWithGoogle({
-        code: 'code',
-        redirectUri: 'https://shareyourgarden.app',
-      }),
-    ).rejects.toThrow(InternalServerErrorException);
+    await service.handleGoogleCallback(req, res);
+
+    expect(cookieMock).toHaveBeenCalledTimes(2);
+    expect(clearCookieMock).toHaveBeenCalledTimes(1);
+    expect(redirectMock).toHaveBeenCalledWith(
+      'https://shareyourgarden.com/app',
+    );
+  });
+
+  it('returns unauthenticated when session is missing', () => {
+    cookieServiceMock.parseCookies.mockReturnValue({});
+    sessionServiceMock.getSession.mockReturnValue(null);
+
+    const result = service.getSession({ headers: {} } as Request);
+
+    expect(result).toEqual({ authenticated: false });
+  });
+
+  it('rejects logout with invalid csrf token', () => {
+    cookieServiceMock.parseCookies.mockReturnValue({
+      syg_session: 'session-id',
+      syg_csrf: 'csrf-a',
+    });
+    sessionServiceMock.getSession.mockReturnValue({
+      id: 'session-id',
+      csrfToken: 'csrf-b',
+      user: { email: 'user@test.com' },
+    });
+
+    expect(() =>
+      service.logout(
+        {
+          headers: { 'x-csrf-token': 'csrf-a', cookie: '...' },
+        } as unknown as Request,
+        { clearCookie: jest.fn() } as unknown as Response,
+      ),
+    ).toThrow(ForbiddenException);
   });
 });

--- a/src/auth/services/auth.service.spec.ts
+++ b/src/auth/services/auth.service.spec.ts
@@ -1,0 +1,86 @@
+import { InternalServerErrorException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthService } from './auth.service';
+import { GoogleOAuthService } from './google-oauth.service';
+import { UsersService } from './users.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+
+  const googleOAuthServiceMock = {
+    validateRedirectUri: jest.fn(),
+    exchangeCodeForIdToken: jest.fn(),
+    verifyIdToken: jest.fn(),
+  };
+
+  const usersServiceMock = {
+    findOrCreateFromGoogle: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    process.env.JWT_SECRET = 'jwt-secret';
+    process.env.JWT_EXPIRES_IN = '1h';
+
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        { provide: GoogleOAuthService, useValue: googleOAuthServiceMock },
+        { provide: UsersService, useValue: usersServiceMock },
+      ],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+  });
+
+  it('returns user and app token on successful login', async () => {
+    googleOAuthServiceMock.exchangeCodeForIdToken.mockResolvedValue('id-token');
+    googleOAuthServiceMock.verifyIdToken.mockResolvedValue({
+      sub: 'sub-1',
+      email: 'test@mail.com',
+      name: 'Test',
+      picture: 'pic',
+    });
+    usersServiceMock.findOrCreateFromGoogle.mockResolvedValue({
+      id: 'user-1',
+      email: 'test@mail.com',
+      name: 'Test',
+      picture: 'pic',
+      roles: ['user'],
+    });
+
+    const result = await service.loginWithGoogle({
+      code: 'code',
+      redirectUri: 'https://shareyourgarden.app',
+    });
+
+    expect(result.user.email).toBe('test@mail.com');
+    expect(result.token.split('.')).toHaveLength(3);
+  });
+
+  it('fails if JWT secret is missing', async () => {
+    delete process.env.JWT_SECRET;
+    googleOAuthServiceMock.exchangeCodeForIdToken.mockResolvedValue('id-token');
+    googleOAuthServiceMock.verifyIdToken.mockResolvedValue({
+      sub: 'sub-1',
+      email: 'test@mail.com',
+      name: 'Test',
+      picture: 'pic',
+    });
+    usersServiceMock.findOrCreateFromGoogle.mockResolvedValue({
+      id: 'user-1',
+      email: 'test@mail.com',
+      name: 'Test',
+      picture: 'pic',
+      roles: ['user'],
+    });
+
+    await expect(
+      service.loginWithGoogle({
+        code: 'code',
+        redirectUri: 'https://shareyourgarden.app',
+      }),
+    ).rejects.toThrow(InternalServerErrorException);
+  });
+});

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -1,0 +1,113 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
+import { createHmac } from 'crypto';
+import { GoogleAuthDto } from '../dto/google-auth.dto';
+import { GoogleOAuthService } from './google-oauth.service';
+import { UsersService } from './users.service';
+
+interface AppJwtPayload {
+  userId: string;
+  email: string;
+  roles: string[];
+}
+
+@Injectable()
+export class AuthService {
+  private readonly logger = new Logger(AuthService.name);
+
+  constructor(
+    private readonly googleOAuthService: GoogleOAuthService,
+    private readonly usersService: UsersService,
+  ) {}
+
+  async loginWithGoogle(dto: GoogleAuthDto) {
+    try {
+      this.googleOAuthService.validateRedirectUri(dto.redirectUri);
+
+      const idToken = await this.googleOAuthService.exchangeCodeForIdToken(
+        dto.code,
+        dto.redirectUri,
+      );
+      const claims = await this.googleOAuthService.verifyIdToken(idToken);
+
+      const user = await this.usersService.findOrCreateFromGoogle({
+        sub: claims.sub,
+        email: claims.email,
+        name: claims.name,
+        picture: claims.picture,
+      });
+
+      const token = this.signToken({
+        userId: user.id,
+        email: user.email,
+        roles: user.roles ?? ['user'],
+      });
+
+      return {
+        user: {
+          sub: claims.sub,
+          email: user.email,
+          name: user.name,
+          picture: user.picture,
+        },
+        token,
+      };
+    } catch (error) {
+      this.logger.error(
+        'Google login failed',
+        error instanceof Error ? error.stack : undefined,
+      );
+      throw error;
+    }
+  }
+
+  private signToken(payload: AppJwtPayload): string {
+    const secret = process.env.JWT_SECRET;
+    if (!secret) {
+      throw new InternalServerErrorException('JWT_SECRET is not configured');
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    const expiresIn = this.parseExpiresIn(process.env.JWT_EXPIRES_IN ?? '1d');
+    const body = {
+      ...payload,
+      iat: now,
+      exp: now + expiresIn,
+    };
+
+    const headerBase64 = this.base64UrlEncode({ alg: 'HS256', typ: 'JWT' });
+    const payloadBase64 = this.base64UrlEncode(body);
+    const signature = createHmac('sha256', secret)
+      .update(`${headerBase64}.${payloadBase64}`)
+      .digest('base64url');
+
+    return `${headerBase64}.${payloadBase64}.${signature}`;
+  }
+
+  private base64UrlEncode(value: object): string {
+    return Buffer.from(JSON.stringify(value)).toString('base64url');
+  }
+
+  private parseExpiresIn(raw: string): number {
+    const match = raw.match(/^(\d+)([smhd])?$/);
+    if (!match) {
+      throw new InternalServerErrorException(
+        'JWT_EXPIRES_IN format is invalid',
+      );
+    }
+
+    const amount = Number.parseInt(match[1], 10);
+    const unit = match[2] ?? 's';
+    const unitInSeconds: Record<string, number> = {
+      s: 1,
+      m: 60,
+      h: 3600,
+      d: 86400,
+    };
+
+    return amount * unitInSeconds[unit];
+  }
+}

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -1,113 +1,179 @@
 import {
+  ForbiddenException,
   Injectable,
   InternalServerErrorException,
   Logger,
+  UnauthorizedException,
 } from '@nestjs/common';
-import { createHmac } from 'crypto';
-import { GoogleAuthDto } from '../dto/google-auth.dto';
+import { Request, Response } from 'express';
 import { GoogleOAuthService } from './google-oauth.service';
+import { AuthFlowService } from './auth-flow.service';
 import { UsersService } from './users.service';
-
-interface AppJwtPayload {
-  userId: string;
-  email: string;
-  roles: string[];
-}
+import { CookieService } from './cookie.service';
+import { SessionService } from './session.service';
 
 @Injectable()
 export class AuthService {
   private readonly logger = new Logger(AuthService.name);
+  private readonly sessionCookieName =
+    process.env.SESSION_COOKIE_NAME ?? 'syg_session';
+  private readonly csrfCookieName = process.env.CSRF_COOKIE_NAME ?? 'syg_csrf';
+  private readonly oauthNonceCookieName = 'syg_oauth_nonce';
 
   constructor(
     private readonly googleOAuthService: GoogleOAuthService,
+    private readonly authFlowService: AuthFlowService,
     private readonly usersService: UsersService,
+    private readonly cookieService: CookieService,
+    private readonly sessionService: SessionService,
   ) {}
 
-  async loginWithGoogle(dto: GoogleAuthDto) {
-    try {
-      this.googleOAuthService.validateRedirectUri(dto.redirectUri);
+  startGoogleAuth(returnTo: string, response: Response): void {
+    this.authFlowService.validateReturnTo(returnTo);
 
-      const idToken = await this.googleOAuthService.exchangeCodeForIdToken(
-        dto.code,
-        dto.redirectUri,
-      );
-      const claims = await this.googleOAuthService.verifyIdToken(idToken);
-
-      const user = await this.usersService.findOrCreateFromGoogle({
-        sub: claims.sub,
-        email: claims.email,
-        name: claims.name,
-        picture: claims.picture,
-      });
-
-      const token = this.signToken({
-        userId: user.id,
-        email: user.email,
-        roles: user.roles ?? ['user'],
-      });
-
-      return {
-        user: {
-          sub: claims.sub,
-          email: user.email,
-          name: user.name,
-          picture: user.picture,
-        },
-        token,
-      };
-    } catch (error) {
-      this.logger.error(
-        'Google login failed',
-        error instanceof Error ? error.stack : undefined,
-      );
-      throw error;
-    }
-  }
-
-  private signToken(payload: AppJwtPayload): string {
-    const secret = process.env.JWT_SECRET;
-    if (!secret) {
-      throw new InternalServerErrorException('JWT_SECRET is not configured');
-    }
-
-    const now = Math.floor(Date.now() / 1000);
-    const expiresIn = this.parseExpiresIn(process.env.JWT_EXPIRES_IN ?? '1d');
-    const body = {
-      ...payload,
-      iat: now,
-      exp: now + expiresIn,
-    };
-
-    const headerBase64 = this.base64UrlEncode({ alg: 'HS256', typ: 'JWT' });
-    const payloadBase64 = this.base64UrlEncode(body);
-    const signature = createHmac('sha256', secret)
-      .update(`${headerBase64}.${payloadBase64}`)
-      .digest('base64url');
-
-    return `${headerBase64}.${payloadBase64}.${signature}`;
-  }
-
-  private base64UrlEncode(value: object): string {
-    return Buffer.from(JSON.stringify(value)).toString('base64url');
-  }
-
-  private parseExpiresIn(raw: string): number {
-    const match = raw.match(/^(\d+)([smhd])?$/);
-    if (!match) {
+    const redirectUri = process.env.GOOGLE_REDIRECT_URI;
+    if (!redirectUri) {
       throw new InternalServerErrorException(
-        'JWT_EXPIRES_IN format is invalid',
+        'GOOGLE_REDIRECT_URI is not configured',
       );
     }
 
-    const amount = Number.parseInt(match[1], 10);
-    const unit = match[2] ?? 's';
-    const unitInSeconds: Record<string, number> = {
-      s: 1,
-      m: 60,
-      h: 3600,
-      d: 86400,
-    };
+    const clientId = process.env.GOOGLE_CLIENT_ID;
+    if (!clientId) {
+      throw new InternalServerErrorException(
+        'GOOGLE_CLIENT_ID is not configured',
+      );
+    }
 
-    return amount * unitInSeconds[unit];
+    const { state, nonce } = this.authFlowService.createOAuthState(returnTo);
+    response.cookie(this.oauthNonceCookieName, nonce, this.cookieOptions(true));
+
+    const params = new URLSearchParams({
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      response_type: 'code',
+      scope: 'openid profile email',
+      state,
+    });
+
+    response.redirect(
+      `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`,
+    );
+  }
+
+  async handleGoogleCallback(
+    request: Request,
+    response: Response,
+  ): Promise<void> {
+    const { code, state } = request.query;
+
+    if (typeof code !== 'string' || typeof state !== 'string') {
+      throw new UnauthorizedException('Missing OAuth callback parameters');
+    }
+
+    const statePayload = this.authFlowService.verifyOAuthState(state);
+    const cookies = this.cookieService.parseCookies(request.headers.cookie);
+    this.authFlowService.ensureNonceMatches(
+      cookies[this.oauthNonceCookieName],
+      statePayload.nonce,
+    );
+
+    this.authFlowService.validateReturnTo(statePayload.returnTo);
+
+    const redirectUri = process.env.GOOGLE_REDIRECT_URI;
+    if (!redirectUri) {
+      throw new InternalServerErrorException(
+        'GOOGLE_REDIRECT_URI is not configured',
+      );
+    }
+
+    const idToken = await this.googleOAuthService.exchangeCodeForIdToken(
+      code,
+      redirectUri,
+    );
+    const claims = await this.googleOAuthService.verifyIdToken(idToken);
+
+    const user = await this.usersService.findOrCreateFromGoogle({
+      sub: claims.sub,
+      email: claims.email,
+      name: claims.name,
+      picture: claims.picture,
+    });
+
+    const session = this.sessionService.createSession({
+      sub: claims.sub,
+      email: user.email,
+      name: user.name,
+      picture: user.picture,
+    });
+
+    response.cookie(
+      this.sessionCookieName,
+      session.id,
+      this.cookieOptions(true),
+    );
+    response.cookie(
+      this.csrfCookieName,
+      session.csrfToken,
+      this.cookieOptions(false),
+    );
+    response.clearCookie(this.oauthNonceCookieName, this.cookieOptions(true));
+
+    this.logger.log(`Google login success user=${user.email}`);
+    response.redirect(statePayload.returnTo);
+  }
+
+  getSession(request: Request) {
+    const cookies = this.cookieService.parseCookies(request.headers.cookie);
+    const session = this.sessionService.getSession(
+      cookies[this.sessionCookieName],
+    );
+
+    if (!session) {
+      return { authenticated: false };
+    }
+
+    return {
+      authenticated: true,
+      user: session.user,
+    };
+  }
+
+  logout(request: Request, response: Response) {
+    const cookies = this.cookieService.parseCookies(request.headers.cookie);
+    const session = this.sessionService.getSession(
+      cookies[this.sessionCookieName],
+    );
+
+    if (!session) {
+      response.clearCookie(this.sessionCookieName, this.cookieOptions(true));
+      response.clearCookie(this.csrfCookieName, this.cookieOptions(false));
+      return { success: true };
+    }
+
+    const csrfHeader = request.headers['x-csrf-token'];
+    const csrfToken = Array.isArray(csrfHeader) ? csrfHeader[0] : csrfHeader;
+    if (
+      csrfToken !== session.csrfToken ||
+      csrfToken !== cookies[this.csrfCookieName]
+    ) {
+      throw new ForbiddenException('Invalid CSRF token');
+    }
+
+    this.sessionService.invalidateSession(session.id);
+    response.clearCookie(this.sessionCookieName, this.cookieOptions(true));
+    response.clearCookie(this.csrfCookieName, this.cookieOptions(false));
+    this.logger.log(`Logout success user=${session.user.email}`);
+
+    return { success: true };
+  }
+
+  private cookieOptions(httpOnly: boolean) {
+    return {
+      httpOnly,
+      secure: true,
+      sameSite: 'none' as const,
+      path: '/',
+    };
   }
 }

--- a/src/auth/services/cookie.service.ts
+++ b/src/auth/services/cookie.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class CookieService {
+  parseCookies(rawCookie: string | undefined): Record<string, string> {
+    if (!rawCookie) {
+      return {};
+    }
+
+    return rawCookie
+      .split(';')
+      .map((cookie) => cookie.trim())
+      .filter(Boolean)
+      .reduce<Record<string, string>>((acc, part) => {
+        const separatorIndex = part.indexOf('=');
+        if (separatorIndex <= 0) {
+          return acc;
+        }
+
+        const key = decodeURIComponent(part.slice(0, separatorIndex));
+        const value = decodeURIComponent(part.slice(separatorIndex + 1));
+        acc[key] = value;
+        return acc;
+      }, {});
+  }
+}

--- a/src/auth/services/google-oauth.service.spec.ts
+++ b/src/auth/services/google-oauth.service.spec.ts
@@ -1,0 +1,101 @@
+import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import { createSign, generateKeyPairSync } from 'crypto';
+import { GoogleOAuthService } from './google-oauth.service';
+
+describe('GoogleOAuthService', () => {
+  let service: GoogleOAuthService;
+
+  beforeEach(() => {
+    process.env.GOOGLE_CLIENT_ID = 'google-client-id';
+    process.env.GOOGLE_CLIENT_SECRET = 'google-client-secret';
+    process.env.GOOGLE_ALLOWED_REDIRECT_URIS = 'https://shareyourgarden.app';
+    service = new GoogleOAuthService();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('validates redirect URI against whitelist', () => {
+    expect(() =>
+      service.validateRedirectUri('https://shareyourgarden.app'),
+    ).not.toThrow();
+    expect(() => service.validateRedirectUri('https://evil.app')).toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('exchanges authorization code for id token', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id_token: 'google-id-token' }),
+    } as Response);
+
+    await expect(
+      service.exchangeCodeForIdToken('code-123', 'https://shareyourgarden.app'),
+    ).resolves.toBe('google-id-token');
+  });
+
+  it('throws unauthorized when google code exchange fails', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({ ok: false } as Response);
+
+    await expect(
+      service.exchangeCodeForIdToken('invalid', 'https://shareyourgarden.app'),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('verifies a valid id token', async () => {
+    const { privateKey, publicKey } = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+    });
+
+    const header = { alg: 'RS256', typ: 'JWT', kid: 'kid-1' };
+    const payload = {
+      iss: 'https://accounts.google.com',
+      aud: 'google-client-id',
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      sub: 'google-sub',
+      email: 'test@example.com',
+      name: 'Test User',
+      picture: 'https://image.test',
+      email_verified: true,
+    };
+
+    const encodedHeader = Buffer.from(JSON.stringify(header)).toString(
+      'base64url',
+    );
+    const encodedPayload = Buffer.from(JSON.stringify(payload)).toString(
+      'base64url',
+    );
+    const signer = createSign('RSA-SHA256');
+    signer.update(`${encodedHeader}.${encodedPayload}`);
+    signer.end();
+    const signature = signer.sign(privateKey).toString('base64url');
+    const token = `${encodedHeader}.${encodedPayload}.${signature}`;
+
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          kid1: publicKey.export({ type: 'spki', format: 'pem' }),
+        }),
+    } as Response);
+
+    await expect(service.verifyIdToken(token)).rejects.toThrow(
+      UnauthorizedException,
+    );
+
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          'kid-1': publicKey.export({ type: 'spki', format: 'pem' }),
+        }),
+    } as Response);
+
+    await expect(service.verifyIdToken(token)).resolves.toMatchObject({
+      sub: 'google-sub',
+      email: 'test@example.com',
+    });
+  });
+});

--- a/src/auth/services/google-oauth.service.ts
+++ b/src/auth/services/google-oauth.service.ts
@@ -1,0 +1,156 @@
+import {
+  ForbiddenException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { createPublicKey, verify } from 'crypto';
+
+interface GoogleTokenResponse {
+  id_token?: string;
+}
+
+interface GoogleIdTokenPayload {
+  iss?: string;
+  aud?: string;
+  exp?: number;
+  sub?: string;
+  email?: string;
+  name?: string;
+  picture?: string;
+  email_verified?: boolean;
+}
+
+interface GoogleCertsResponse {
+  [kid: string]: string;
+}
+
+@Injectable()
+export class GoogleOAuthService {
+  private getAllowedRedirectUris(): string[] {
+    return (process.env.GOOGLE_ALLOWED_REDIRECT_URIS ?? '')
+      .split(',')
+      .map((uri) => uri.trim())
+      .filter(Boolean);
+  }
+
+  validateRedirectUri(redirectUri: string): void {
+    const allowedUris = this.getAllowedRedirectUris();
+    if (allowedUris.length > 0 && !allowedUris.includes(redirectUri)) {
+      throw new ForbiddenException('redirectUri is not allowed');
+    }
+  }
+
+  async exchangeCodeForIdToken(
+    code: string,
+    redirectUri: string,
+  ): Promise<string> {
+    const params = new URLSearchParams({
+      client_id: process.env.GOOGLE_CLIENT_ID ?? '',
+      client_secret: process.env.GOOGLE_CLIENT_SECRET ?? '',
+      grant_type: 'authorization_code',
+      redirect_uri: redirectUri,
+      code,
+    });
+
+    const response = await fetch('https://oauth2.googleapis.com/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: params,
+    });
+
+    if (!response.ok) {
+      throw new UnauthorizedException('Invalid authorization code');
+    }
+
+    const payload = (await response.json()) as GoogleTokenResponse;
+    if (!payload.id_token) {
+      throw new UnauthorizedException('Google response missing id_token');
+    }
+
+    return payload.id_token;
+  }
+
+  async verifyIdToken(
+    idToken: string,
+  ): Promise<Required<GoogleIdTokenPayload>> {
+    const [encodedHeader, encodedPayload, encodedSignature] =
+      idToken.split('.');
+    if (!encodedHeader || !encodedPayload || !encodedSignature) {
+      throw new UnauthorizedException('Malformed id_token');
+    }
+
+    const header = JSON.parse(this.base64UrlDecode(encodedHeader)) as {
+      alg?: string;
+      kid?: string;
+    };
+    if (header.alg !== 'RS256' || !header.kid) {
+      throw new UnauthorizedException('Unsupported id_token header');
+    }
+
+    const payload = JSON.parse(
+      this.base64UrlDecode(encodedPayload),
+    ) as GoogleIdTokenPayload;
+
+    const certsResponse = await fetch(
+      'https://www.googleapis.com/oauth2/v1/certs',
+    );
+    if (!certsResponse.ok) {
+      throw new UnauthorizedException('Could not fetch Google certificates');
+    }
+
+    const certs = (await certsResponse.json()) as GoogleCertsResponse;
+    const certPem = certs[header.kid];
+    if (!certPem) {
+      throw new UnauthorizedException('Unknown Google key id');
+    }
+
+    const verifier = verify(
+      'RSA-SHA256',
+      Buffer.from(`${encodedHeader}.${encodedPayload}`),
+      createPublicKey(certPem),
+      this.base64UrlToBuffer(encodedSignature),
+    );
+
+    if (!verifier) {
+      throw new UnauthorizedException('Invalid Google token signature');
+    }
+
+    const nowInSeconds = Math.floor(Date.now() / 1000);
+    const validIssuer =
+      payload.iss === 'accounts.google.com' ||
+      payload.iss === 'https://accounts.google.com';
+
+    if (!validIssuer) {
+      throw new UnauthorizedException('Invalid token issuer');
+    }
+
+    if (payload.aud !== process.env.GOOGLE_CLIENT_ID) {
+      throw new UnauthorizedException('Invalid token audience');
+    }
+
+    if (!payload.exp || payload.exp <= nowInSeconds) {
+      throw new UnauthorizedException('Expired Google token');
+    }
+
+    if (
+      !payload.sub ||
+      !payload.email ||
+      !payload.name ||
+      payload.email_verified !== true
+    ) {
+      throw new UnauthorizedException('Invalid Google user claims');
+    }
+
+    return payload as Required<GoogleIdTokenPayload>;
+  }
+
+  private base64UrlDecode(value: string): string {
+    return this.base64UrlToBuffer(value).toString('utf8');
+  }
+
+  private base64UrlToBuffer(value: string): Buffer {
+    const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+    return Buffer.from(padded, 'base64');
+  }
+}

--- a/src/auth/services/session.service.ts
+++ b/src/auth/services/session.service.ts
@@ -1,0 +1,65 @@
+import { Injectable } from '@nestjs/common';
+import { randomBytes } from 'crypto';
+
+export interface SessionUser {
+  sub: string;
+  email: string;
+  name: string;
+  picture?: string;
+}
+
+interface SessionRecord {
+  id: string;
+  user: SessionUser;
+  csrfToken: string;
+  expiresAt: number;
+}
+
+@Injectable()
+export class SessionService {
+  private readonly sessions = new Map<string, SessionRecord>();
+  private readonly ttlMs = Number.parseInt(
+    process.env.SESSION_TTL_MS ?? '86400000',
+    10,
+  );
+
+  createSession(user: SessionUser): SessionRecord {
+    const id = randomBytes(32).toString('hex');
+    const csrfToken = randomBytes(16).toString('hex');
+    const record: SessionRecord = {
+      id,
+      user,
+      csrfToken,
+      expiresAt: Date.now() + this.ttlMs,
+    };
+
+    this.sessions.set(id, record);
+    return record;
+  }
+
+  getSession(id: string | undefined): SessionRecord | null {
+    if (!id) {
+      return null;
+    }
+
+    const current = this.sessions.get(id);
+    if (!current) {
+      return null;
+    }
+
+    if (current.expiresAt <= Date.now()) {
+      this.sessions.delete(id);
+      return null;
+    }
+
+    return current;
+  }
+
+  invalidateSession(id: string | undefined): void {
+    if (!id) {
+      return;
+    }
+
+    this.sessions.delete(id);
+  }
+}

--- a/src/auth/services/users.service.spec.ts
+++ b/src/auth/services/users.service.spec.ts
@@ -1,0 +1,97 @@
+import { getModelToken } from '@nestjs/mongoose';
+import { Test, TestingModule } from '@nestjs/testing';
+import { User } from '../schemas/user.schema';
+import { UsersService } from './users.service';
+
+describe('UsersService', () => {
+  let service: UsersService;
+
+  const userModelMock = {
+    findOne: jest.fn(),
+    create: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        { provide: getModelToken(User.name), useValue: userModelMock },
+      ],
+    }).compile();
+
+    service = module.get<UsersService>(UsersService);
+  });
+
+  it('creates a user when none exists', async () => {
+    userModelMock.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+    userModelMock.create.mockResolvedValue({
+      _id: { toString: () => '1' },
+      email: 'mail@test.com',
+      name: 'Name',
+      roles: ['user'],
+    });
+
+    const result = await service.findOrCreateFromGoogle({
+      sub: 'sub-1',
+      email: 'mail@test.com',
+      name: 'Name',
+      picture: 'pic',
+    });
+
+    expect(userModelMock.create).toHaveBeenCalled();
+    expect(result.id).toBe('1');
+  });
+
+  it('updates existing user by googleSub', async () => {
+    const save = jest.fn().mockResolvedValue({
+      _id: { toString: () => '2' },
+      email: 'new@test.com',
+      name: 'New Name',
+      picture: 'new-pic',
+      roles: ['user'],
+    });
+    userModelMock.findOne.mockResolvedValueOnce({
+      googleSub: 'sub-1',
+      email: 'old@test.com',
+      name: 'Old',
+      save,
+    });
+
+    await service.findOrCreateFromGoogle({
+      sub: 'sub-1',
+      email: 'new@test.com',
+      name: 'New Name',
+      picture: 'new-pic',
+    });
+
+    expect(save).toHaveBeenCalled();
+    expect(userModelMock.create).not.toHaveBeenCalled();
+  });
+
+  it('links existing user by email with google sub', async () => {
+    const save = jest.fn().mockResolvedValue({
+      _id: { toString: () => '3' },
+      email: 'mail@test.com',
+      name: 'Name',
+      picture: 'pic',
+      roles: ['user'],
+    });
+    userModelMock.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce({
+      email: 'mail@test.com',
+      save,
+    });
+
+    await service.findOrCreateFromGoogle({
+      sub: 'sub-3',
+      email: 'mail@test.com',
+      name: 'Name',
+      picture: 'pic',
+    });
+
+    expect(save).toHaveBeenCalled();
+  });
+});

--- a/src/auth/services/users.service.ts
+++ b/src/auth/services/users.service.ts
@@ -1,0 +1,73 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { User, UserDocument } from '../schemas/user.schema';
+
+export interface GoogleProfile {
+  sub: string;
+  email: string;
+  name: string;
+  picture?: string;
+}
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  name: string;
+  picture?: string;
+  roles: string[];
+}
+
+@Injectable()
+export class UsersService {
+  constructor(
+    @InjectModel(User.name) private readonly userModel: Model<UserDocument>,
+  ) {}
+
+  async findOrCreateFromGoogle(profile: GoogleProfile): Promise<AuthUser> {
+    const normalizedEmail = profile.email.toLowerCase();
+
+    const userBySub = await this.userModel.findOne({ googleSub: profile.sub });
+    if (userBySub) {
+      userBySub.name = profile.name;
+      userBySub.picture = profile.picture;
+      userBySub.email = normalizedEmail;
+      userBySub.provider = 'google';
+      const saved = await userBySub.save();
+      return this.toAuthUser(saved);
+    }
+
+    const userByEmail = await this.userModel.findOne({
+      email: normalizedEmail,
+    });
+    if (userByEmail) {
+      userByEmail.name = profile.name;
+      userByEmail.picture = profile.picture;
+      userByEmail.googleSub = profile.sub;
+      userByEmail.provider = 'google';
+      const saved = await userByEmail.save();
+      return this.toAuthUser(saved);
+    }
+
+    const created = await this.userModel.create({
+      name: profile.name,
+      email: normalizedEmail,
+      picture: profile.picture,
+      googleSub: profile.sub,
+      provider: 'google',
+      roles: ['user'],
+    });
+
+    return this.toAuthUser(created);
+  }
+
+  private toAuthUser(user: UserDocument): AuthUser {
+    return {
+      id: user._id.toString(),
+      email: user.email,
+      name: user.name,
+      picture: user.picture,
+      roles: user.roles ?? ['user'],
+    };
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,9 +2,49 @@ import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
+function getCorsAllowlist(): string[] {
+  return (process.env.FRONTEND_RETURN_TO_ALLOWLIST ?? '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function matchesPattern(value: string, pattern: string): boolean {
+  if (!pattern.includes('*')) {
+    return value === pattern;
+  }
+
+  const escaped = pattern
+    .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*/g, '.*');
+  return new RegExp(`^${escaped}$`).test(value);
+}
+
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  app.enableCors();
+  const allowlist = getCorsAllowlist();
+
+  app.enableCors({
+    credentials: true,
+    origin: (
+      origin: string | undefined,
+      callback: (error: Error | null, allow?: boolean) => void,
+    ) => {
+      if (!origin) {
+        callback(null, true);
+        return;
+      }
+
+      const allowed = allowlist.some((pattern) =>
+        matchesPattern(origin, pattern),
+      );
+      callback(
+        allowed ? null : new Error('Origin not allowed by CORS'),
+        allowed,
+      );
+    },
+  });
+
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,
@@ -12,6 +52,8 @@ async function bootstrap() {
       transform: true,
     }),
   );
+
   await app.listen(process.env.PORT ?? 1337);
 }
+
 void bootstrap();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,17 @@
+import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.enableCors();
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
   await app.listen(process.env.PORT ?? 1337);
 }
-bootstrap();
+void bootstrap();

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,19 +1,25 @@
-import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { App } from 'supertest/types';
-import { AppModule } from './../src/app.module';
+import { AppController } from './../src/app.controller';
+import { AppService } from './../src/app.service';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication<App>;
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
+      controllers: [AppController],
+      providers: [AppService],
     }).compile();
 
     app = moduleFixture.createNestApplication();
     await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
   });
 
   it('/ (GET)', () => {

--- a/test/auth-google.e2e-spec.ts
+++ b/test/auth-google.e2e-spec.ts
@@ -1,0 +1,64 @@
+import { ValidationPipe } from '@nestjs/common';
+import { INestApplication } from '@nestjs/common/interfaces';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { AuthController } from '../src/auth/auth.controller';
+import { GoogleAuthRateLimitGuard } from '../src/auth/guards/google-auth-rate-limit.guard';
+import { AuthService } from '../src/auth/services/auth.service';
+
+describe('Auth Google endpoint (e2e)', () => {
+  let app: INestApplication<App>;
+
+  const authServiceMock = {
+    loginWithGoogle: jest.fn().mockResolvedValue({
+      user: {
+        name: 'Test User',
+        email: 'test@example.com',
+        picture: 'https://image',
+        sub: 'google-sub',
+      },
+      token: 'app-jwt-token',
+    }),
+  };
+
+  beforeEach(async () => {
+    const moduleFixture = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [
+        GoogleAuthRateLimitGuard,
+        { provide: AuthService, useValue: authServiceMock },
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }),
+    );
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('POST /auth/google returns user and token', async () => {
+    await request(app.getHttpServer())
+      .post('/auth/google')
+      .send({ code: 'valid-code', redirectUri: 'https://shareyourgarden.app' })
+      .expect(200)
+      .expect(
+        ({ body }: { body: { user: { email: string }; token: string } }) => {
+          expect(body.user.email).toBe('test@example.com');
+          expect(body.token).toBe('app-jwt-token');
+        },
+      );
+  });
+
+  it('POST /auth/google validates payload', async () => {
+    await request(app.getHttpServer())
+      .post('/auth/google')
+      .send({ code: '', redirectUri: 'invalid' })
+      .expect(400);
+  });
+});

--- a/test/auth-google.e2e-spec.ts
+++ b/test/auth-google.e2e-spec.ts
@@ -1,35 +1,75 @@
-import { ValidationPipe } from '@nestjs/common';
-import { INestApplication } from '@nestjs/common/interfaces';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import * as request from 'supertest';
 import { App } from 'supertest/types';
 import { AuthController } from '../src/auth/auth.controller';
 import { GoogleAuthRateLimitGuard } from '../src/auth/guards/google-auth-rate-limit.guard';
+import { AuthFlowService } from '../src/auth/services/auth-flow.service';
 import { AuthService } from '../src/auth/services/auth.service';
+import { CookieService } from '../src/auth/services/cookie.service';
+import { GoogleOAuthService } from '../src/auth/services/google-oauth.service';
+import { SessionService } from '../src/auth/services/session.service';
+import { UsersService } from '../src/auth/services/users.service';
 
-describe('Auth Google endpoint (e2e)', () => {
+function readSetCookies(headers: unknown): string[] {
+  if (!headers || typeof headers !== 'object') {
+    return [];
+  }
+
+  const value = (headers as Record<string, unknown>)['set-cookie'];
+  if (Array.isArray(value)) {
+    return value.filter(
+      (cookie): cookie is string => typeof cookie === 'string',
+    );
+  }
+
+  return typeof value === 'string' ? [value] : [];
+}
+
+describe('Auth broker endpoints (e2e)', () => {
   let app: INestApplication<App>;
+  let flowService: AuthFlowService;
 
-  const authServiceMock = {
-    loginWithGoogle: jest.fn().mockResolvedValue({
-      user: {
-        name: 'Test User',
-        email: 'test@example.com',
-        picture: 'https://image',
-        sub: 'google-sub',
-      },
-      token: 'app-jwt-token',
+  const googleOAuthServiceMock = {
+    exchangeCodeForIdToken: jest.fn().mockResolvedValue('id-token'),
+    verifyIdToken: jest.fn().mockResolvedValue({
+      sub: 'google-sub',
+      email: 'user@test.com',
+      name: 'User',
+      picture: 'pic',
+    }),
+  };
+
+  const usersServiceMock = {
+    findOrCreateFromGoogle: jest.fn().mockResolvedValue({
+      email: 'user@test.com',
+      name: 'User',
+      picture: 'pic',
     }),
   };
 
   beforeEach(async () => {
+    process.env.SESSION_SECRET = 'session-secret';
+    process.env.GOOGLE_CLIENT_ID = 'google-client-id';
+    process.env.GOOGLE_REDIRECT_URI =
+      'https://api.shareyourgarden.com/auth/google/callback';
+    process.env.FRONTEND_RETURN_TO_ALLOWLIST =
+      'https://shareyourgarden.com,https://deploy-preview-*.--shareyourgarden.netlify.app';
+
     const moduleFixture = await Test.createTestingModule({
       controllers: [AuthController],
       providers: [
+        AuthService,
+        AuthFlowService,
+        CookieService,
+        SessionService,
         GoogleAuthRateLimitGuard,
-        { provide: AuthService, useValue: authServiceMock },
+        { provide: GoogleOAuthService, useValue: googleOAuthServiceMock },
+        { provide: UsersService, useValue: usersServiceMock },
       ],
     }).compile();
+
+    flowService = moduleFixture.get(AuthFlowService);
 
     app = moduleFixture.createNestApplication();
     app.useGlobalPipes(
@@ -42,23 +82,69 @@ describe('Auth Google endpoint (e2e)', () => {
     await app.close();
   });
 
-  it('POST /auth/google returns user and token', async () => {
+  it('GET /auth/google/start accepts netlify preview return_to', async () => {
+    const returnTo =
+      'https://deploy-preview-123.--shareyourgarden.netlify.app/dashboard';
+
     await request(app.getHttpServer())
-      .post('/auth/google')
-      .send({ code: 'valid-code', redirectUri: 'https://shareyourgarden.app' })
-      .expect(200)
-      .expect(
-        ({ body }: { body: { user: { email: string }; token: string } }) => {
-          expect(body.user.email).toBe('test@example.com');
-          expect(body.token).toBe('app-jwt-token');
-        },
-      );
+      .get('/auth/google/start')
+      .query({ return_to: returnTo })
+      .expect(302)
+      .expect((res) => {
+        expect(res.headers.location).toContain(
+          'accounts.google.com/o/oauth2/v2/auth',
+        );
+      });
   });
 
-  it('POST /auth/google validates payload', async () => {
+  it('full callback -> session -> logout flow', async () => {
+    const returnTo = 'https://shareyourgarden.com/app';
+    const { state, nonce } = flowService.createOAuthState(returnTo);
+
+    const callbackResponse = await request(app.getHttpServer())
+      .get('/auth/google/callback')
+      .set('Cookie', [`syg_oauth_nonce=${nonce}`])
+      .query({ code: 'auth-code', state })
+      .expect(302);
+
+    expect(callbackResponse.headers.location).toBe(returnTo);
+
+    const setCookies = readSetCookies(callbackResponse.headers);
+    const sessionCookie = setCookies.find((cookie) =>
+      cookie.startsWith('syg_session='),
+    );
+    const csrfCookie = setCookies.find((cookie) =>
+      cookie.startsWith('syg_csrf='),
+    );
+    expect(sessionCookie).toBeDefined();
+    expect(csrfCookie).toBeDefined();
+
+    const sessionValue = sessionCookie?.split(';')[0] ?? '';
+    const csrfValue = csrfCookie?.split(';')[0] ?? '';
+    const csrfToken = csrfValue.split('=')[1] ?? '';
+
     await request(app.getHttpServer())
-      .post('/auth/google')
-      .send({ code: '', redirectUri: 'invalid' })
-      .expect(400);
+      .get('/auth/session')
+      .set('Cookie', [sessionValue])
+      .expect(200)
+      .expect(
+        ({
+          body,
+        }: {
+          body: { authenticated: boolean; user: { email: string } };
+        }) => {
+          expect(body.authenticated).toBe(true);
+          expect(body.user.email).toBe('user@test.com');
+        },
+      );
+
+    await request(app.getHttpServer())
+      .post('/auth/logout')
+      .set('Cookie', [sessionValue, csrfValue])
+      .set('x-csrf-token', csrfToken)
+      .expect(200)
+      .expect(({ body }: { body: { success: boolean } }) => {
+        expect(body.success).toBe(true);
+      });
   });
 });


### PR DESCRIPTION
### Motivation
- Añadir backend que complete el Authorization Code Flow de Google recibido desde el frontend, persista/actualice usuarios y devuelva un token de aplicación junto al perfil.

### Description
- Añadido endpoint `POST /auth/google` con DTO `GoogleAuthDto` y validación global (`ValidationPipe`), y un guard rate-limit por IP (`GoogleAuthRateLimitGuard`).
- Implementado intercambio de `code` contra `https://oauth2.googleapis.com/token` y verificación de `id_token` incluyendo firma RS256 (obtención de certs de Google), `iss`, `aud`, `exp` y claims (`sub`, `email`, `name`, `picture`, `email_verified`).
- Añadido `User` schema (Mongoose) y `UsersService` que busca por `googleSub` o `email`, crea usuario si no existe y actualiza solo campos de perfil no sensibles; guarda `provider=google` y `googleSub`.
- Generación de JWT de la aplicación con claims mínimos (`userId`, `email`, `roles`) usando HS256 implementado con `crypto` para evitar dependencias adicionales, y respuesta unificada `{ user, token }`; además se actualizaron `.env.example` y `README` con variables requeridas (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_ALLOWED_REDIRECT_URIS`, `JWT_SECRET`, `JWT_EXPIRES_IN`, etc.).

### Testing
- Ejecutado `yarn lint` y corregidos avisos/errores locales; resultado final: lint pasó.
- Ejecutado `yarn test --runInBand` (unit tests) y todas las suites unitarias pasaron.
- Ejecutado `yarn test:e2e --runInBand` (integración) y las pruebas e2e añadidas pasaron.
- Se añadieron tests unitarios y e2e para validación de payload, intercambio de código (mock de Google), verificación de `id_token`, creación/actualización de usuario y el endpoint `/auth/google`, y todos los tests creados pasaron exitosamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8a88efa48832bbe23cfbfcec9f3b1)